### PR TITLE
amend load print for better consistency

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -458,4 +458,6 @@ minetest.register_chatcommand("sed", {
 })
 
 minetest.after(interval, sedimentology)
-print("Initialized Sedimentology")
+
+-- print to log after mod was loaded successfully
+print ("[MOD] Sedimentology loaded")


### PR DESCRIPTION
Amend the message text of final **print to log** at the end of `init.lua` to indicate the mod was loaded successfully. Make the message more consistent with other mods.